### PR TITLE
Simplify regex for links

### DIFF
--- a/assets/app/shared/directives/bunkerMessage.js
+++ b/assets/app/shared/directives/bunkerMessage.js
@@ -39,7 +39,7 @@ app.directive('bunkerMessage', function ($compile, emoticons) {
 
 				// Parse links
 				var attachedImage;
-				_.each(text.match(/((http|ftp|https):\/\/)?[\w-]+(\.[\w-]+)+([\w.,@?^=%&amp;:/~+#-]*[\w@?^=%&amp;/~+#-])?/gi), function (link) {
+				_.each(text.match(/https?:\/\/\S+/gi), function (link) {
 					if (/\.(gif|png|jpg|jpeg)$/i.test(link) && !attachedImage) {
 						// Image link
 						attachedImage = angular.element('<div bunker-message-image="' + link + '"></div>');


### PR DESCRIPTION
Has to start with http(s).
And that’s it!
